### PR TITLE
Update presentations.md

### DIFF
--- a/presentations.md
+++ b/presentations.md
@@ -29,6 +29,6 @@
 
 ## Week 09
 
-- NAME, TOPIC/PAPER
+- Bailey Fernandez, Kit Fine --- "Truthmaker Semantics" (focus on how it handles modality)
 - NAME, TOPIC/PAPER
 


### PR DESCRIPTION
Put myself down for Week 9 to present on Kit Fine´s Truthmaker Semantics. Given the class and the topic of Ben´s paper Id like to do so in a way that focuses on its way of handling modality. 

Currently reading this paper: Fine, Kit (2017). A Theory of Truthmaker Content I: Conjunction, Disjunction and Negation. Journal of Philosophical Logic 46 (6):625-674. 10.1007/s10992-016-9413-y
However, I would be happy to switch to one which more directly handles how he conceives "possible states" etc 